### PR TITLE
PR: Ensure that the flatten function can take null and undefined as arguments

### DIFF
--- a/test/iterable.test.ts
+++ b/test/iterable.test.ts
@@ -63,6 +63,17 @@ describe('flatten()', function () {
 		const expected = ["annotation", undefined, 1, null, undefined, "simplicity"]
 		assert.deepEqual(actual, expected)
 	})
+
+	it('should ignore null or undefined elements passed as input', function () {
+		// eslint-disable-next-line fp/no-let, init-declarations
+		let actual: unknown
+		assert.doesNotThrow(() => {
+			// eslint-disable-next-line fp/no-mutation
+			actual = [...flatten([["annotation"], null, undefined, ["simplicity"]])]
+		})
+		const expected = ["annotation", "simplicity"]
+		assert.deepEqual(actual, expected)
+	})
 })
 
 describe('take()', function () {

--- a/test/iterable.test.ts
+++ b/test/iterable.test.ts
@@ -53,7 +53,7 @@ describe('flatten()', function () {
 		assert.deepEqual(actual, expected)
 	})
 
-	it('should be able to handle null or undefined elements inside input iterable', function () {
+	it('should be able to handle null or undefined elements inside input iterables', function () {
 		// eslint-disable-next-line fp/no-let, init-declarations
 		let actual: unknown
 		assert.doesNotThrow(() => {
@@ -64,7 +64,7 @@ describe('flatten()', function () {
 		assert.deepEqual(actual, expected)
 	})
 
-	it('should be able to handle null or undefined elements among other input iterable', function () {
+	it('should be able to handle null or undefined elements among other input iterables', function () {
 		// eslint-disable-next-line fp/no-let, init-declarations
 		let actual: unknown
 		assert.doesNotThrow(() => {

--- a/test/iterable.test.ts
+++ b/test/iterable.test.ts
@@ -64,14 +64,14 @@ describe('flatten()', function () {
 		assert.deepEqual(actual, expected)
 	})
 
-	it('should ignore null or undefined elements passed as input', function () {
+	it('should allow null or undefined to be passed among the iterables', function () {
 		// eslint-disable-next-line fp/no-let, init-declarations
 		let actual: unknown
 		assert.doesNotThrow(() => {
 			// eslint-disable-next-line fp/no-mutation
 			actual = [...flatten([["annotation"], null, undefined, ["simplicity"]])]
 		})
-		const expected = ["annotation", "simplicity"]
+		const expected = ["annotation", null, undefined, "simplicity"]
 		assert.deepEqual(actual, expected)
 	})
 })

--- a/test/iterable.test.ts
+++ b/test/iterable.test.ts
@@ -53,7 +53,7 @@ describe('flatten()', function () {
 		assert.deepEqual(actual, expected)
 	})
 
-	it('should be able to handle null or undefined elements in input iterable', function () {
+	it('should be able to handle null or undefined elements inside input iterable', function () {
 		// eslint-disable-next-line fp/no-let, init-declarations
 		let actual: unknown
 		assert.doesNotThrow(() => {
@@ -64,7 +64,7 @@ describe('flatten()', function () {
 		assert.deepEqual(actual, expected)
 	})
 
-	it('should allow null or undefined to be passed among the iterables', function () {
+	it('should be able to handle null or undefined elements among other input iterable', function () {
 		// eslint-disable-next-line fp/no-let, init-declarations
 		let actual: unknown
 		assert.doesNotThrow(() => {


### PR DESCRIPTION
Resolves #53 

**Merge message:**
Added a unit test ensuring that the flatten function still works when it receives null and undefined among the other arguments.