### PR TITLE
PR: Filter out non-objects from the deepmerge function

### DIFF
--- a/src/collections/object.ts
+++ b/src/collections/object.ts
@@ -143,9 +143,11 @@ export function deepMerge(...args: any[])/*: O.Compact<T, Tn, 'deep'>*/ {
 		return result
 	}
 
-	return [...skip(args, 1)].reduce((result, newComer) => {
+	// We ignore arguments that aren't objects
+	const validObjects = args.filter(obj => typeof obj === "object" && !Array.isArray(obj) && obj !== null)
+	return [...skip(validObjects, 1)].reduce((result, newComer) => {
 		return mergeRecursively(result, newComer)
-	}, args[0]) //as O.Compact<T, Tn, 'deep'>
+	}, validObjects[0]) //as O.Compact<T, Tn, 'deep'>
 }
 
 // const m = (deepMerge({ n: 1 }, { str: "num" }))

--- a/test/object.test.ts
+++ b/test/object.test.ts
@@ -157,6 +157,18 @@ describe('merge', () => {
 		assert.throws(() => deepMerge(null, {}))
 	})*/
 
+	it('ignores all arguments that are not object', function () {
+		assert.deepEqual(deepMerge({ a: 11 }, undefined, 58, { b: 99 }), { a: 11, b: 99 })
+	})
+
+	it('ignores all objects that are not plain object', function () {
+		assert.deepEqual(deepMerge({ a: 11 }, null, [], { b: 99 }), { a: 11, b: 99 })
+	})
+
+	it('doesn\'t override objects when a function is part of the arguments', function () {
+		assert.deepEqual(deepMerge({ a: 11 }, () => 2, { b: 99 }), { a: 11, b: 99 })
+	})
+
 	it('returns an empty object if passed empty objects', function () {
 		assert.deepEqual(deepMerge({}, {}, {}), {})
 	})


### PR DESCRIPTION
Resolves #62 

Note: Upon merging, the version of this "Standard" library should be upgraded, and then used in the "Somatic" library.

**Merge message:**
- Filtered out non-objects (and array objects) from the "deepMerge" function, preventing valid objects from being given unexpected values (like `undefined`) during a merge.
- Added a couple unit test to verify that passing Primitives, arrays, null and functions as argument of "deepMerge" doesn't cause unexpected behaviors.