### PR TITLE
PR: Reimplement the outlier filter

### DIFF
--- a/src/collections/containers/table.ts
+++ b/src/collections/containers/table.ts
@@ -1,3 +1,4 @@
+/* eslint-disable fp/no-mutation */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable indent */
@@ -7,6 +8,8 @@
 
 import { Obj, ExtractByType, Primitive, hasValue } from "../../utility"
 import { zip } from "../iterable"
+import { ArrayNumeric } from "./array"
+import { mean, deviation } from "../../statistical"
 import { Predicate, Projector, getRanker } from "../../functional"
 import { Dictionary } from "./dictionary"
 import { Sequence } from "./sequence"
@@ -93,6 +96,7 @@ export class DataTable<T extends Obj = Obj> /*implements Table<T>*/ {
 
 	/** Return a new data table that excludes data disallowed by the passed filters */
 	filter(args: { filter?: Predicate<T, void> | TableFilter | FilterGroup, options?: FilterOptions }): DataTable<T> {
+
 		const shouldRetain = (row: T, filter: Predicate<T, void> | TableFilter | FilterGroup): boolean => {
 			if ("filters" in filter) {
 				switch (filter.combinator) {
@@ -107,6 +111,27 @@ export class DataTable<T extends Obj = Obj> /*implements Table<T>*/ {
 				}
 			}
 			else if ("fieldName" in filter) {
+				// eslint-disable-next-line fp/no-let
+				let averageAndDev: { average: number, std: number } = { average: 0, std: 0 }
+				if (filter.operator === "is_outlier_by") {
+					const originalIdVector = this.idVector
+					const colVector: unknown[] = filter.fieldName === "rowId" ? originalIdVector : this._colVectors.get(filter.fieldName as keyof T)
+					if (colVector === undefined) {
+						throw new Error(`Trying to apply a filter on column ${filter.fieldName}, but no such column in the dataTable`)
+					}
+					const vector: number[] = colVector.filter(v => v !== undefined).map(val => Number.parseFloat(String(val)))
+					const columnMean = mean(vector)
+					const stdv = deviation(vector, { mean: columnMean, forSample: true })
+					if (columnMean === undefined) { throw new Error("Undefined mean, cannot filter by standard deviation") }
+					if (stdv === undefined) { throw new Error("Undefined std dev, cannot filter by standard deviation") }
+
+					averageAndDev = {
+						average: columnMean,
+						std: stdv
+					}
+				}
+				console.log(averageAndDev)
+
 				const _test = filter.negated ? false : true
 				const _val = row[filter.fieldName as keyof T]
 
@@ -127,11 +152,11 @@ export class DataTable<T extends Obj = Obj> /*implements Table<T>*/ {
 					case "less_or_equal":
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
 						return (parseFloat(String(_val)) <= parseFloat(filter.value as any)) === _test
-					case "is_outlier_by":
-						// const belowMin = parseFloat(_val) < filter.average! - parseFloat(filter.value as any) * filter.std!
-						// const aboveMax = parseFloat(_val) > filter.average! + parseFloat(filter.value as any) * filter.std!
-						// return (belowMin || aboveMax) === _test
-						return true
+					case "is_outlier_by": {
+						const belowMin = parseFloat(String(_val)) < averageAndDev.average - parseFloat(filter.value as any) * averageAndDev.std
+						const aboveMax = parseFloat(String(_val)) > averageAndDev.average + parseFloat(filter.value as any) * averageAndDev.std
+						return (belowMin || aboveMax) === _test
+					}
 					case "contains":
 						return (hasValue(_val) && String(_val).indexOf(filter.value) >= 0) === _test
 					case "is-contained":

--- a/src/collections/containers/table.ts
+++ b/src/collections/containers/table.ts
@@ -130,7 +130,6 @@ export class DataTable<T extends Obj = Obj> /*implements Table<T>*/ {
 						std: stdv
 					}
 				}
-				console.log(averageAndDev)
 
 				const _test = filter.negated ? false : true
 				const _val = row[filter.fieldName as keyof T]

--- a/src/statistical/index.ts
+++ b/src/statistical/index.ts
@@ -87,8 +87,8 @@ export function variance(vector: number[], opts?:
 		? opts.mean
 		: mean(vector, opts?.mean)
 
-	return _mean
-		? sum(vector.filter(noop).map(datum => Math.pow(datum - _mean, 2))) / (len - ((opts?.forSample ?? true) ? 1 : 0))
+	return _mean !== undefined
+		? sum(vector.map(datum => Math.pow(datum - _mean, 2))) / (len - ((opts?.forSample ?? true) ? 1 : 0))
 		: undefined
 }
 
@@ -102,7 +102,7 @@ export function deviation(vector: number[], opts?:
 	}): number | undefined {
 
 	const _variance = variance(vector, opts)
-	return _variance ? Math.sqrt(_variance) : undefined
+	return _variance !== undefined ? Math.sqrt(_variance) : undefined
 }
 
 export function median<T>(vector: Array<T>): T | undefined {

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -1,3 +1,28 @@
+import * as assert from "assert"
+import { DataTable } from "../dist/collections/containers"
+
+describe("filtering", () => {
+	it(`should sort the outliers correctly`, () => {
+		const startingDT = new DataTable([
+			{ v: 1, color: "Green" },
+			{ v: 5, color: "Orange" },
+			{ v: 1, color: "Green" },
+			{ v: 2, color: "Green" },
+			{ v: 25, color: "Red" },
+			{ v: 36, color: "Red" },
+			{ v: 7, color: "Orange" },
+			{ v: 3, color: "Green" },
+			{ v: 2, color: "Green" },
+			{ v: 1, color: "Green" }])
+		const filteredDT = startingDT
+			.filter({ filter: { negated: true, fieldName: "v", operator: "is_outlier_by", value: 1 } })
+		assert.equal(filteredDT.length, 8)
+		assert.equal([...filteredDT.rowObjects].filter(row => row.color === "Red").length, 0)
+		const unfilteredDt = startingDT
+			.filter({ filter: { negated: true, fieldName: "v", operator: "is_outlier_by", value: 5 } })
+		assert.equal(unfilteredDt.length, 10)
+	})
+})
 /* // data-table tests
 	describe("page", () => {
 		it(`should return the original rows if page (original) is called several time in a row`, () => {

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -18,9 +18,39 @@ describe("filtering", () => {
 			.filter({ filter: { negated: true, fieldName: "v", operator: "is_outlier_by", value: 1 } })
 		assert.equal(filteredDT.length, 8)
 		assert.equal([...filteredDT.rowObjects].filter(row => row.color === "Red").length, 0)
-		const unfilteredDt = startingDT
+	})
+	it(`should remove outliers correctly with positive and negative values`, () => {
+		const startingDT = new DataTable([
+			{ v: -1, color: "Green" },
+			{ v: 5, color: "Orange" },
+			{ v: 1, color: "Green" },
+			{ v: 2, color: "Green" },
+			{ v: -25, color: "Red" },
+			{ v: 36, color: "Red" },
+			{ v: 7, color: "Orange" },
+			{ v: 3, color: "Green" },
+			{ v: -2, color: "Green" },
+			{ v: 1, color: "Green" }])
+		const filteredDT = startingDT
+			.filter({ filter: { negated: true, fieldName: "v", operator: "is_outlier_by", value: 1 } })
+		assert.equal(filteredDT.length, 8)
+		assert.equal([...filteredDT.rowObjects].filter(row => row.color === "Red").length, 0)
+	})
+	it(`should not remove the outliers when the number of standard deviation is too high`, () => {
+		const startingDT = new DataTable([
+			{ v: 1, color: "Green" },
+			{ v: 5, color: "Orange" },
+			{ v: 1, color: "Green" },
+			{ v: 2, color: "Green" },
+			{ v: 25, color: "Red" },
+			{ v: 36, color: "Red" },
+			{ v: 7, color: "Orange" },
+			{ v: 3, color: "Green" },
+			{ v: 2, color: "Green" },
+			{ v: 1, color: "Green" }])
+		const filteredDT = startingDT
 			.filter({ filter: { negated: true, fieldName: "v", operator: "is_outlier_by", value: 5 } })
-		assert.equal(unfilteredDt.length, 10)
+		assert.equal(filteredDT.length, 10)
 	})
 })
 /* // data-table tests

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -1,5 +1,3 @@
-
-
 /* // data-table tests
 	describe("page", () => {
 		it(`should return the original rows if page (original) is called several time in a row`, () => {


### PR DESCRIPTION
Resolves #65

**Merge message:**
- Re-implemented the outlier filter for the table container
- Fixed the code that calculate variances, which until now always returned 0 (the part that calculated the mean of the vector used the sum of `vector.filter(noop)`, which was always an empty vector)
- Updated the code for the calculation of variance and deviation to replace implicit undefined check (`variance ? Math.sqrt(_variance) : undefined`) by explicit ones (`variance !== undefined ? Math.sqrt(_variance) : undefined`), to prevent variances of 0 being treated as undefined.
- Added 3 unit tests for the outlier filter