### PR TITLE
PR: Fix the getRanker function

### DIFF
--- a/src/functional/index.ts
+++ b/src/functional/index.ts
@@ -41,7 +41,7 @@ export function getComparer<T>(projector: Projector<T, unknown, void>, tryNumeri
 	}
 }
 /** Compares 2 values and sort them, possibly parsing it as date or number beforehand.
- * If the values have a different types, string values will always be sorted in last position.
+ * If the 2 compared values have a differnt type, the string type will always be ranked last, unless the user choses (through 'tryNumeric') to convert number-likes strings into numbers for comparison.
  * @param larger One value to compare
  * @param smaller The other value to compare
  * @param projector A projector used to find the values to compare, if the passed values are objects

--- a/src/functional/index.ts
+++ b/src/functional/index.ts
@@ -40,6 +40,14 @@ export function getComparer<T>(projector: Projector<T, unknown, void>, tryNumeri
 		return compare(x, y, projector, tryNumeric, tryDate) === 0
 	}
 }
+/** Compares 2 values and sort them, possibly parsing it as date or number beforehand.
+ * If the values have a different types, string values will always be sorted in last position.
+ * @param larger One value to compare
+ * @param smaller The other value to compare
+ * @param projector A projector used to find the values to compare, if the passed values are objects
+ * @param tryNumeric If any or both of the two values are strings, an attempt will be made to parse them as number before doing to comparison
+ * @param tryDateAsNumeric If both values are strings corresponding to dates, they will be parsed as Dates and compared as such.
+ */
 export function compare<T>(larger: T, smaller: T, projector?: Projector<T, unknown, void>, tryNumeric = false, tryDateAsNumeric = false): -1 | 0 | 1 {
 	const _larger: unknown = projector ? projector(larger) : larger
 	const _smaller: unknown = projector ? projector(smaller) : smaller

--- a/src/functional/index.ts
+++ b/src/functional/index.ts
@@ -41,7 +41,7 @@ export function getComparer<T>(projector: Projector<T, unknown, void>, tryNumeri
 	}
 }
 /** Compares 2 values and sort them, possibly parsing it as date or number beforehand.
- * If the 2 compared values have a differnt type, the string type will always be ranked last, unless the user choses (through 'tryNumeric') to convert number-likes strings into numbers for comparison.
+ * If the 2 compared values have a different type, the string type will always be ranked last, unless the user choses (through 'tryNumeric') to convert number-likes strings into numbers for comparison.
  * @param larger One value to compare
  * @param smaller The other value to compare
  * @param projector A projector used to find the values to compare, if the passed values are objects

--- a/src/functional/index.ts
+++ b/src/functional/index.ts
@@ -40,14 +40,14 @@ export function getComparer<T>(projector: Projector<T, unknown, void>, tryNumeri
 		return compare(x, y, projector, tryNumeric, tryDate) === 0
 	}
 }
-export function compare<T>(larger: T, smaller: T, projector?: Projector<T, unknown, void>, tryNumeric = false, tryDate = false): -1 | 0 | 1 {
+export function compare<T>(larger: T, smaller: T, projector?: Projector<T, unknown, void>, tryNumeric = false, tryDateAsNumeric = false): -1 | 0 | 1 {
 	const _larger: unknown = projector ? projector(larger) : larger
 	const _smaller: unknown = projector ? projector(smaller) : smaller
 
 	const sign = (n: number) => Math.sign(n) as -1 | 0 | 1
 
 	if (typeof _larger === "string" && typeof _smaller === "string") {
-		if (tryDate === true) {
+		if (tryDateAsNumeric === true) {
 			const __x = new Date(_larger)
 			const __y = new Date(_smaller)
 			if (__x > __y)
@@ -80,8 +80,29 @@ export function compare<T>(larger: T, smaller: T, projector?: Projector<T, unkno
 		else
 			return -1
 	}
-	else
+	else if (typeof _larger !== typeof _smaller) { // When both values have different types
+		if (tryNumeric) {
+			const _largerNum = typeof _larger === "number"
+				? _larger
+				: typeof _larger === "string"
+					? parseFloat(_larger)
+					: 0
+			const _smallerNum = typeof _smaller === "number"
+				? _smaller
+				: typeof _smaller === "string"
+					? parseFloat(_smaller)
+					: 0
+			// If both types could succesfully be turned into numbers, we compare it numerically
+			if (!isNaN(_smallerNum) && !isNaN(_largerNum)) {
+				return sign(_largerNum - _smallerNum)
+			}
+		}
+		return typeof _larger === "string" ? 1 : -1 // Strings will appear last
+	}
+	else {
 		return _larger === _smaller ? 0 : 1
+
+	}
 }
 
 export const noop = () => { }

--- a/test/functional.test.ts
+++ b/test/functional.test.ts
@@ -1,10 +1,11 @@
+/* eslint-disable fp/no-mutating-methods */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable fp/no-unused-expression */
 // /* eslint-disable fp/no-unused-expression */
 
 // import mocha from "mocha"
 import * as assert from "assert"
-import { compare, flip, curry } from '../dist/functional/index.js'
+import { compare, getRanker } from '../dist/functional/index.js'
 
 
 describe('compare()', () => {
@@ -32,6 +33,79 @@ describe('compare()', () => {
 		const x = "2012-05-06 11:20:30"
 		const y = "2012-05-06 11:20:32"
 		assert.equal(compare(x, y, undefined, false, true) < 0, true)
+	})
+})
+
+describe('getRanker()', () => {
+	it(`should rank numbers correctly`, () => {
+		const series = [7, 7, 7, 2, 5, 3, 4, 5, 5, 6]
+		const sortedSeries = series.sort(
+			getRanker({
+				projector: v => v
+			})
+		)
+		assert.strictEqual(JSON.stringify(sortedSeries), JSON.stringify([2, 3, 4, 5, 5, 5, 6, 7, 7, 7]))
+	})
+	it(`should rank text correctly`, () => {
+		const series = ["banana", "apple", "lemon", "apple", "citrus"]
+		const sortedSeries = series.sort(
+			getRanker({
+				projector: v => v
+			})
+		)
+		assert.strictEqual(JSON.stringify(sortedSeries), JSON.stringify(["apple", "apple", "banana", "citrus", "lemon",]))
+	})
+	it(`should rank number and text separately`, () => {
+		const series = ["Blue", "Blue", 2, 5, 3, "Blue", 4, "Green", 5, 5, 6, 7, 7, 7, "Green"]
+		const sortedSeries = series.sort(
+			getRanker({
+				projector: v => v
+			})
+		)
+		assert.strictEqual(JSON.stringify(sortedSeries), JSON.stringify([2, 3, 4, 5, 5, 5, 6, 7, 7, 7, "Blue", "Blue", "Blue", "Green", "Green"]))
+	})
+	it(`should rank number and text correctly as text, if no option is precised`, () => {
+		const mixedseries = ["Blue", "Blue", 2, 5, 3, "Blue", 4, "Green", 5, 5, 6, 7, 7, 7, "Green"]
+		const textSeries = ["Blue", "Blue", "2", "5", "3", "Blue", "4", "Green", "5", "5", "6", "7", "7", "7", "Green"]
+		const ranker = getRanker({
+			projector: v => v
+		})
+		const sortedMixedSeries = mixedseries.sort(ranker)
+		const sortedTextSeries = textSeries.sort(ranker)
+
+		assert.strictEqual(JSON.stringify(sortedMixedSeries), JSON.stringify(sortedTextSeries.map(v => parseInt(v) || v)))
+	})
+	it(`should rank strings as number, if tryNumeric is set`, () => {
+		const series = ["Blue", "0", 2, 5, 3, "15", 4, "Green", 5, 5, 6, 7, 7, 7, "Green"]
+		// eslint-disable-next-line fp/no-mutating-methods
+		const sortedSeries = series.sort(
+			getRanker({
+				projector: v => v,
+				tryNumeric: true
+			})
+		)
+		assert.strictEqual(JSON.stringify(sortedSeries), JSON.stringify(["0", 2, 3, 4, 5, 5, 5, 6, 7, 7, 7, "15", "Blue", "Green", "Green"]))
+	})
+	it(`should rank dates as number, if tryDate is set`, () => {
+		const series = ["December 1 1991", "December 1 1991", "December 2 1991", "December 5 1991", "April 5, 2001"]
+		// eslint-disable-next-line fp/no-mutating-methods
+		const sortedSeries = series.sort(
+			getRanker({
+				projector: v => v,
+				tryDate: true
+			})
+		)
+		assert.strictEqual(JSON.stringify(sortedSeries), JSON.stringify(["December 1 1991", "December 1 1991", "December 2 1991", "December 5 1991", "April 5, 2001"]))
+	})
+	it(`should rank dates as strings, if tryDate is not set`, () => {
+		const series = ["December 1 1991", "December 1 1991", "December 2 1991", "December 5 1991", "April 5, 2001", "December 5 1995"]
+		// eslint-disable-next-line fp/no-mutating-methods
+		const sortedSeries = series.sort(
+			getRanker({
+				projector: v => v
+			})
+		)
+		assert.strictEqual(JSON.stringify(sortedSeries), JSON.stringify(["April 5, 2001", "December 1 1991", "December 1 1991", "December 2 1991", "December 5 1991", "December 5 1995"]))
 	})
 })
 


### PR DESCRIPTION
Resolves #73 

**Merge message:**
Updated the `compare()` function of the library, so that when the 2 compared values have a different type, the string type will always be ranked last, unless the user chooses (by passing 'tryNumeric'=true) to convert number-like strings into numbers for comparison.

As a result, sorting arrays of strings & numbers with the 'getRanker' function results in both being well-separated `(1, 3, 5, 8, "Blue", "Green", "Yellow")`, instead of interleaved like before `("Blue", 3, "Green", 1, 5, "Yellow", 7)`