### PR TITLE
PR: Update ci-checks-actions to version to 2.0.3

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -39,7 +39,7 @@ jobs:
         continue-on-error: true
          
       - name: Annotate Code Checks Results
-        uses: agyemanjp/ci-checks-action@2.0.2
+        uses: agyemanjp/ci-checks-action@2.0.3
         with:
           ghToken: "${{ secrets.GITHUB_TOKEN }}"
           checks: '[


### PR DESCRIPTION
Updated ci-checks-actions used on the github workflow to version to 2.0.3