### PR TITLE
PR: Fix glob pattern in the lint npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"scripts": {
 		"setup": "rm -rf ./node_modules package-lock.json && npm install",
 		"clean": "rm -rf dist/* .eslintcache *-report.json",
-		"lint": "eslint --ext ts --cache src/*",
+		"lint": "eslint --ext ts --cache src/**",
 		"lint-report": "eslint --ext ts --output-file .lint-report.json --format json-standard --cache src/*",
 		"compile": "tsc",
 		"test": "mocha --require ts-node/register test/*.test.*",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"scripts": {
 		"setup": "rm -rf ./node_modules package-lock.json && npm install",
 		"clean": "rm -rf dist/* .eslintcache *-report.json",
-		"lint": "eslint --ext ts --cache src/**",
+		"lint": "eslint --ext ts --cache 'src/**'",
 		"lint-report": "eslint --ext ts --output-file .lint-report.json --format json-standard --cache src/*",
 		"compile": "tsc",
 		"test": "mocha --require ts-node/register test/*.test.*",


### PR DESCRIPTION
**title**
fix: (#86) Fix glob pattern in the lint npm script

**merge message**
Resolves #86 

Fixed glob pattern in the “lint” npm script to match all files under “./src”