### PR TITLE
PR: Fix mode calculation for binary vectors and include support of multimodal vectors

### DIFF
--- a/src/statistical/index.ts
+++ b/src/statistical/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable no-shadow */
 /* eslint-disable brace-style */
@@ -133,11 +134,24 @@ export function thirdQuartile<T>(vector: Array<T>, ranker?: Ranker<T>) {
 	return sortedList[Math.ceil(0.75 * sortedList.length) - 1]
 }
 
-export function mode<T>(vector: Array<T>): T | undefined {
+export function mode<T>(vector: Array<T>): T[] | undefined {
 	if (vector.length === 0) return undefined
-	const freqs = sort([...frequencies(vector).entries()], ((a, b) => a[1] - b[1]))
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	return last(freqs)![0]
+
+	return (vector.reduce((accu, curr) => {
+		const freqsMap = accu.freqsMap
+		freqsMap.set(curr, (freqsMap.get(curr) || 0) + 1)
+
+		const maxCount = freqsMap.get(curr)! > accu.maxCount
+			? freqsMap.get(curr)!
+			: accu.maxCount
+		const modes = freqsMap.get(curr) === accu.maxCount
+			? [...accu.modes, curr]
+			: freqsMap.get(curr)! > accu.maxCount
+				? [curr]
+				: accu.modes
+
+		return { freqsMap, maxCount, modes }
+	}, { freqsMap: new globalThis.Map<T, number>(), maxCount: 1, modes: [] as T[] })).modes
 }
 
 export function interQuartileRange(vector: number[]) {

--- a/src/statistical/index.ts
+++ b/src/statistical/index.ts
@@ -134,8 +134,11 @@ export function thirdQuartile<T>(vector: Array<T>, ranker?: Ranker<T>) {
 	return sortedList[Math.ceil(0.75 * sortedList.length) - 1]
 }
 
-export function mode<T>(vector: Array<T>): T[] | undefined {
-	if (vector.length === 0) return undefined
+/**
+ * Computes the mode of a set of values. It returns an array of all the modes found
+ */
+export function multiMode<T>(vector: Array<T>): T[] {
+	if (vector.length === 0) return []
 
 	return (vector.reduce((accu, curr) => {
 		const freqsMap = accu.freqsMap
@@ -151,7 +154,23 @@ export function mode<T>(vector: Array<T>): T[] | undefined {
 				: accu.modes
 
 		return { freqsMap, maxCount, modes }
-	}, { freqsMap: new globalThis.Map<T, number>(), maxCount: 1, modes: [] as T[] })).modes
+	}, { freqsMap: new globalThis.Map<T, number>(), maxCount: 1, modes: [] as T[] })).modes	
+}
+
+/**
+ * Computes the mode of a set of values. It uses the "multimode" function but instead of
+ * returning an array of values, it will pick the middle one after sorting the modes array
+ */
+export function mode<T>(vector: Array<T>): T | undefined {
+	if (vector.length === 0) return undefined
+
+	// eslint-disable-next-line fp/no-mutating-methods
+	const modes = multiMode(vector).sort()
+	const index = modes.length % 2 === 0 
+		? (modes.length / 2) - 1
+		: Math.floor(modes.length / 2)
+
+	return modes[index]
 }
 
 export function interQuartileRange(vector: number[]) {

--- a/src/statistical/index.ts
+++ b/src/statistical/index.ts
@@ -135,7 +135,7 @@ export function thirdQuartile<T>(vector: Array<T>, ranker?: Ranker<T>) {
 
 export function mode<T>(vector: Array<T>): T | undefined {
 	if (vector.length === 0) return undefined
-	const freqs = sort([...frequencies(vector).entries()], (x => x[1]))
+	const freqs = sort([...frequencies(vector).entries()], ((a, b) => a[1] - b[1]))
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	return last(freqs)![0]
 }

--- a/test/statistical.test.ts
+++ b/test/statistical.test.ts
@@ -7,7 +7,7 @@
 import * as assert from "assert"
 import {
 	min, max, sum, mean,
-	median, mode, variance, deviation, firstQuartile, thirdQuartile, interQuartileRange,
+	median, mode, multiMode, variance, deviation, firstQuartile, thirdQuartile, interQuartileRange,
 	frequencies
 } from "../dist/statistical"
 
@@ -91,35 +91,65 @@ describe('mode()', function () {
 	
 	it('should return 1 when passing an array of 3 zeros and 4 ones', function () {
 		const actual = mode([1, 0, 1, 0, 1, 0, 1])
-		const expected = [1]
+		const expected = 1
 
 		assert.deepEqual(actual, expected)
 	})
 
 	it('should return 1 when passing an array of 3 zeros and 4 ones but sorted in ascending order', function () {
 		const actual = mode([0, 0, 0, 1, 1, 1, 1])
-		const expected = [1]
+		const expected = 1
 
 		assert.deepEqual(actual, expected)
 	})
 
-	it('should return 5 when passing an array of different values but with the 5 value element with more occurrences', function () {
+	it('should return 5 when passing an array of different values but with the value "5" with more occurrences', function () {
 		const actual = mode([3, 5, 6, 7, 3, 2, 13, 45, 43, 23, 13, 45, 5, 6, 7, 5, 14, 4])
-		const expected = [5]
+		const expected = 5
 
 		assert.deepEqual(actual, expected)
 	})
 
-	it('should return an array with multiple modes when passing an array of three values with the same occurrences', function () {
+	it('should return the middle value of all the possible modes when passing an array of three values with the same occurrences', function () {
 		const actual = mode([3, 5, 6, 7, 5, 5, 6, 6, 3, 3])
+		const expected = 5
+
+		assert.deepEqual(actual, expected)
+	})
+
+	it('should return the middle value of all the possible modes when passing an array with every element having the same occurrences', function () {
+		const actual = mode([1, 2, 3, 4])
+		const expected = 2
+
+		assert.deepEqual(actual, expected)
+	})
+
+	it('should return the middle value of all the possible modes when passing an array with number and characters', function () {
+		const actual = mode([2, 2 , 'a', 'a', 'v', 'v'])
+		const expected = 'a'
+
+		assert.deepEqual(actual, expected)
+	})
+})
+
+describe('multimode()', function () {
+	it('should return an array with multiple modes when passing an array of three values with the same occurrences', function () {
+		const actual = multiMode([3, 5, 6, 7, 5, 5, 6, 6, 3, 3])
 		const expected = [5, 6, 3]
 
 		assert.deepEqual(actual, expected)
 	})
 
 	it('should return the same array when passing an array with every element having the same occurrences', function () {
-		const actual = mode([1, 2, 3, 4 ,5])
+		const actual = multiMode([1, 2, 3, 4, 5])
 		const expected = [1, 2, 3, 4, 5]
+
+		assert.deepEqual(actual, expected)
+	})
+
+	it('should return an array of all the possible modes when passing an array with number and characters', function () {
+		const actual = multiMode([2, 2, 'a', 'a', 'v', 'v'])
+		const expected = [2, 'a', 'v']
 
 		assert.deepEqual(actual, expected)
 	})

--- a/test/statistical.test.ts
+++ b/test/statistical.test.ts
@@ -81,3 +81,26 @@ describe('sum()', function () {
 	})
 
 })
+
+describe('mode()', function () {
+	it('should return 1 when passing an array of 3 zeros and 4 ones', function () {
+		const actual = mode([1, 0, 1, 0, 1, 0, 1])
+		const expected = 1
+
+		assert.deepEqual(actual, expected)
+	})
+
+	it('should return 1 when passing an array of 3 zeros and 4 ones but sorted in ascending order', function () {
+		const actual = mode([0, 0, 0, 1, 1, 1, 1])
+		const expected = 1
+
+		assert.deepEqual(actual, expected)
+	})
+
+	it('should return 5 when passing an array of different values but with more 5s', function () {
+		const actual = mode([3, 5, 6, 7, 3, 2, 13, 45, 43, 23, 13, 45, 5, 6, 7, 5, 14, 4])
+		const expected = 5
+
+		assert.deepEqual(actual, expected)
+	})
+})

--- a/test/statistical.test.ts
+++ b/test/statistical.test.ts
@@ -83,23 +83,43 @@ describe('sum()', function () {
 })
 
 describe('mode()', function () {
+	it ('should return undefined when passing an empty array', () => {
+		const actual = mode([])
+		const expected = undefined
+		assert.deepEqual(actual, expected)
+	})
+	
 	it('should return 1 when passing an array of 3 zeros and 4 ones', function () {
 		const actual = mode([1, 0, 1, 0, 1, 0, 1])
-		const expected = 1
+		const expected = [1]
 
 		assert.deepEqual(actual, expected)
 	})
 
 	it('should return 1 when passing an array of 3 zeros and 4 ones but sorted in ascending order', function () {
 		const actual = mode([0, 0, 0, 1, 1, 1, 1])
-		const expected = 1
+		const expected = [1]
 
 		assert.deepEqual(actual, expected)
 	})
 
-	it('should return 5 when passing an array of different values but with more 5s', function () {
+	it('should return 5 when passing an array of different values but with the 5 value element with more occurrences', function () {
 		const actual = mode([3, 5, 6, 7, 3, 2, 13, 45, 43, 23, 13, 45, 5, 6, 7, 5, 14, 4])
-		const expected = 5
+		const expected = [5]
+
+		assert.deepEqual(actual, expected)
+	})
+
+	it('should return an array with multiple modes when passing an array of three values with the same occurrences', function () {
+		const actual = mode([3, 5, 6, 7, 5, 5, 6, 6, 3, 3])
+		const expected = [5, 6, 3]
+
+		assert.deepEqual(actual, expected)
+	})
+
+	it('should return the same array when passing an array with every element having the same occurrences', function () {
+		const actual = mode([1, 2, 3, 4 ,5])
+		const expected = [1, 2, 3, 4, 5]
 
 		assert.deepEqual(actual, expected)
 	})

--- a/test/statistical.test.ts
+++ b/test/statistical.test.ts
@@ -132,7 +132,13 @@ describe('mode()', function () {
 	})
 })
 
-describe('multimode()', function () {
+describe('multiMode()', function () {
+	it('should return an empty array when passing an empty vector', () => {
+		const actual = multiMode([])
+		const expected = [] as string[]
+		assert.deepEqual(actual, expected)
+	})
+
 	it('should return an array with multiple modes when passing an array of three values with the same occurrences', function () {
 		const actual = multiMode([3, 5, 6, 7, 5, 5, 6, 6, 3, 3])
 		const expected = [5, 6, 3]


### PR DESCRIPTION
**title**
feat: (#88)  Fix mode calculation for binary vectors and include support of multimodal vectors

**merge message**

Resolves #88 

- Created function "multiMode" to support calculation of multiple modes.
- Modified "mode" function to fix bug with binary data and to return the middle value from an array of multiple modes.
- Added unit tests for each case.