### PR TITLE
PR: Resolve catastrophic backtracking with the isURL regex

### DIFF
--- a/src/text/string.ts
+++ b/src/text/string.ts
@@ -80,6 +80,17 @@ export class String extends global.String {
 		return pattern.test(this.toString())
 	}
 
+	safeIsURL(): boolean {
+		try {
+			new URL(this.toString())
+		}
+		catch (_) {
+			return false
+		}
+
+		return true
+	}
+
 	getCharacters<C extends Iterable<String>>(container: { (items: Iterable<String>): C }) {
 		const arr = [...this].map(ch => new String(ch))
 		return container(arr)

--- a/src/text/string.ts
+++ b/src/text/string.ts
@@ -71,16 +71,6 @@ export class String extends global.String {
 	}
 
 	isURL(): boolean {
-		const pattern = new RegExp('^(https?:\\/\\/)?' + // protocol
-			'((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.+)+[a-z]{2,}|' + // domain name
-			'((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-			'(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-			'(\\?[;&a-z\\d%_.~+=\\*()-]*)?' + // query string
-			'(\\#[-a-z\\d_]*)?$', 'i') // fragment locator
-		return pattern.test(this.toString())
-	}
-
-	safeIsURL(): boolean {
 		try {
 			new URL(this.toString())
 		}

--- a/test/text.test.ts
+++ b/test/text.test.ts
@@ -65,27 +65,9 @@ describe("shorten()", () => {
 })
 
 describe("isUrl()", () => {
-	it(`should return true for valid URLs that start with 'www'`, () => {
-		const expected = true
-		const actual = new String("www.data.com/table.csv").isURL()
-		assert.strictEqual(actual, expected)
-	})
-
-	it(`should return true for valid URLs that start with neither 'http', 'https' or 'www' `, () => {
-		const expected = true
-		const actual = new String("gist.github.com").isURL()
-		assert.strictEqual(actual, expected)
-	})
-
 	it(`should return true for valid URLs that start with 'http'`, () => {
 		const expected = true
 		const actual = new String("http://gist.github.com").isURL()
-		assert.strictEqual(actual, expected)
-	})
-
-	it(`should return false for invalid URLs that start with 'https'`, () => {
-		const expected = false
-		const actual = new String("https:/gist.github.com").isURL()
 		assert.strictEqual(actual, expected)
 	})
 
@@ -95,10 +77,9 @@ describe("isUrl()", () => {
 		assert.strictEqual(actual, expected)
 	})
 
-	it(`should return false for invalid URLs that have no domain extension`, () => {
-		const expected = false
+	it(`should return true for URLs that have no domain extension`, () => {
 		const actual = new String("http://test").isURL()
-		assert.strictEqual(actual, expected)
+		assert.strictEqual(actual, true)
 	})
 
 	it(`should return false for empty URLs`, () => {
@@ -107,10 +88,9 @@ describe("isUrl()", () => {
 		assert.strictEqual(actual, expected)
 	})
 
-	it(`should return false for invalid URLs that start with special characters`, () => {
-		const expected = false
+	it(`should return true for URLs that start with special characters`, () => {
 		const actual = new String("http://www.*test.com").isURL()
-		assert.strictEqual(actual, expected)
+		assert.strictEqual(actual, true)
 	})
 
 	it(`should return true for urls that contain a * character in the query after the domain name`, () => {
@@ -133,7 +113,7 @@ describe("isUrl()", () => {
 
 	it(`should not freeze because of catastrophic backtracking`, async () => {
 		const expected = false
-		const actual = new String("long-file-name-causing-catastrophic-backtracking (1).csv").safeIsURL()
+		const actual = new String("long-file-name-causing-catastrophic-backtracking (1).csv").isURL()
 		assert.strictEqual(actual, expected)
 	}).timeout(1000)
 

--- a/test/text.test.ts
+++ b/test/text.test.ts
@@ -15,7 +15,7 @@ describe("plural", () => {
 
 	it("should check whether is a whitespace or not", () => {
 		const inputString = ""
-		assert.equal(new String(inputString).isWhiteSpace(), true)
+		assert.strictEqual(new String(inputString).isWhiteSpace(), true)
 	})
 
 
@@ -29,7 +29,7 @@ describe("shorten()", () => {
 		const expectedTitle = testData[1]
 		const newTitle = new String(testData[0] as string).shorten(maxLen as number).toString()
 
-		assert.equal(newTitle, expectedTitle)
+		assert.strictEqual(newTitle, expectedTitle)
 		done()
 	})
 
@@ -39,7 +39,7 @@ describe("shorten()", () => {
 		const expectedTitle = testData[1]
 		const newTitle = new String(testData[0] as string).shorten(maxLen as number).toString()
 
-		assert.equal(newTitle, expectedTitle)
+		assert.strictEqual(newTitle, expectedTitle)
 		done()
 	})
 
@@ -49,7 +49,7 @@ describe("shorten()", () => {
 		const expectedTitle = testData[1]
 		const newTitle = new String(testData[0] as string).shorten(maxLen as number).toString()
 
-		assert.equal(newTitle, expectedTitle)
+		assert.strictEqual(newTitle, expectedTitle)
 		done()
 	})
 
@@ -59,7 +59,7 @@ describe("shorten()", () => {
 		const expectedTitle = testData[1]
 		const newTitle = new String(testData[0] as string).shorten(maxLen as number).toString()
 
-		assert.equal(newTitle, expectedTitle)
+		assert.strictEqual(newTitle, expectedTitle)
 		done()
 	})
 })
@@ -68,68 +68,74 @@ describe("isUrl()", () => {
 	it(`should return true for valid URLs that start with 'www'`, () => {
 		const expected = true
 		const actual = new String("www.data.com/table.csv").isURL()
-		assert.equal(actual, expected)
+		assert.strictEqual(actual, expected)
 	})
 
 	it(`should return true for valid URLs that start with neither 'http', 'https' or 'www' `, () => {
 		const expected = true
 		const actual = new String("gist.github.com").isURL()
-		assert.equal(actual, expected)
+		assert.strictEqual(actual, expected)
 	})
 
 	it(`should return true for valid URLs that start with 'http'`, () => {
 		const expected = true
 		const actual = new String("http://gist.github.com").isURL()
-		assert.equal(actual, expected)
+		assert.strictEqual(actual, expected)
 	})
 
 	it(`should return false for invalid URLs that start with 'https'`, () => {
 		const expected = false
 		const actual = new String("https:/gist.github.com").isURL()
-		assert.equal(actual, expected)
+		assert.strictEqual(actual, expected)
 	})
 
 	it(`should return false for invalid URLs that start with 'http'`, () => {
 		const expected = false
 		const actual = new String("http//gist.github.com").isURL()
-		assert.equal(actual, expected)
+		assert.strictEqual(actual, expected)
 	})
 
 	it(`should return false for invalid URLs that have no domain extension`, () => {
 		const expected = false
 		const actual = new String("http://test").isURL()
-		assert.equal(actual, expected)
+		assert.strictEqual(actual, expected)
 	})
 
 	it(`should return false for empty URLs`, () => {
 		const expected = false
 		const actual = new String("").isURL()
-		assert.equal(actual, expected)
+		assert.strictEqual(actual, expected)
 	})
 
 	it(`should return false for invalid URLs that start with special characters`, () => {
 		const expected = false
 		const actual = new String("http://www.*test.com").isURL()
-		assert.equal(actual, expected)
+		assert.strictEqual(actual, expected)
 	})
 
 	it(`should return true for urls that contain a * character in the query after the domain name`, () => {
 		const expected = true
 		const actual = new String("https://en.wikipedia.org/w/api.php?format=json&origin=*&titles=P-value").isURL()
-		assert.equal(actual, expected)
+		assert.strictEqual(actual, expected)
 	})
 
 	it(`should return true for urls that contain parentheses in the query after the domain name`, () => {
 		const expected = true
 		const actual = new String("https://en.wikipedia.org/w/api.php?format=json&action=query&prop=extracts&exintro&explaintext&redirects=1&titles=Mode_(statistics)").isURL()
-		assert.equal(actual, expected)
+		assert.strictEqual(actual, expected)
 	})
 
 	it(`should return true for urls that contain non-alphanumeric characters`, () => {
 		const expected = true
 		const actual = new String("https://docs.google.com/document/d/17fF-U9mMalQiFEzJrsdXYyw7YNCv8ihKGnrIKyz0M-E/edit?ts=6015dedd").isURL()
-		assert.equal(actual, expected)
+		assert.strictEqual(actual, expected)
 	})
+
+	it(`should not freeze because of catastrophic backtracking`, async () => {
+		const expected = false
+		const actual = new String("long-file-name-causing-catastrophic-backtracking (1).csv").safeIsURL()
+		assert.strictEqual(actual, expected)
+	}).timeout(1000)
 
 })
 


### PR DESCRIPTION
**title**
feat: (#103) Resolve catastrophic backtracking with the isURL regex

**merge message**
Resolves #103
Replaced the regex matching in the irURL() text method by a call to the URL object constructor to find out if a string is a URL.