### PR TITLE
PR: Fix the return type of function "keys"

### DIFF
--- a/src/stats/index.ts
+++ b/src/stats/index.ts
@@ -124,11 +124,13 @@ export function median<T>(vector: Array<T>): T | undefined {
 	}
 }
 
+/** Vector will be sorted alphabetically by default */
 export function firstQuartile<T>(vector: Array<T>, ranker?: Ranker<T>) {
 	const sortedList = sort(vector, ranker)
 	return sortedList[Math.floor(0.25 * sortedList.length)]
 }
 
+/** Vector will be sorted alphabetically by default */
 export function thirdQuartile<T>(vector: Array<T>, ranker?: Ranker<T>) {
 	const sortedList = sort(vector, ranker)
 	return sortedList[Math.ceil(0.75 * sortedList.length) - 1]


### PR DESCRIPTION
Title
fix: Fix the return type of function "keys"

**Merge message:**
Resolves https://github.com/Hypothesize/standard.js/issues/118

Re-typed the function "keys" of the object library, to indicate that it will always return arrays of strings and nothing else.