### PR TITLE
PR: Fix the return type of function "keys"

### DIFF
--- a/src/object/index.ts
+++ b/src/object/index.ts
@@ -9,10 +9,9 @@
 import { Tuple, Obj, Merge, isObject, isSymbol } from "../utility"
 
 export function keys<T extends Obj>(obj: T): (keyof T)[]
-export function keys<K extends string | number | symbol, V>(obj: Record<K, V>): K[]
+export function keys<K extends string | number | symbol, V>(obj: Record<K, V>): string[]
 export function keys(obj: any) {
-	// if (typeof obj === "object") throw new Error
-	return Object.keys(obj)
+    return Object.keys(obj)
 }
 
 export function objectFromTuples<T, K extends string = string>(keyValues: Tuple<K, T>[]) {


### PR DESCRIPTION
**Title**
fix: Fix the return type of function "keys"

**Merge message:**
Resolves https://github.com/Hypothesize/standard.js/issues/118

Re-typed the function "keys" of the object library, to indicate that it will always return arrays of strings and nothing else.